### PR TITLE
fix: add support for github dark theme

### DIFF
--- a/packages/github/src/components/LinearIssuesContainer.tsx
+++ b/packages/github/src/components/LinearIssuesContainer.tsx
@@ -15,7 +15,7 @@ export interface LinearIssuesContainerProps {
 export const LinearIssuesContainer: FC<LinearIssuesContainerProps> = ({ className, codes }) => (
   <QueryClientProvider>
     <div className={cn('w-full', className)} ref={setTooltipRoot}>
-      <div className="border border-gray-300 rounded-md w-full">
+      <div className="border border-[--borderColor-default] rounded-md w-full">
         {codes.length === 0 && (
           <div className="flex gap-1.5 items-center px-2 py-1.5">
             <img alt="LAGE Icon" className="size-8" src={iconImage} />
@@ -38,7 +38,10 @@ export const LinearIssuesContainer: FC<LinearIssuesContainerProps> = ({ classNam
           getLinearClient(code) ? (
             <LinearIssue key={code} code={code} />
           ) : (
-            <div key={code} className="flex items-center gap-1.5 border-b border-gray-300 last:border-0 px-4 py-2">
+            <div
+              key={code}
+              className="flex items-center gap-1.5 border-b border-[--borderColor-default] last:border-0 px-4 py-2"
+            >
               <img alt="LAGE Icon" className="size-6" src={iconImage} />
               <div>
                 Linear not connected for team

--- a/packages/linear/src/components/LinearIssue.tsx
+++ b/packages/linear/src/components/LinearIssue.tsx
@@ -38,7 +38,7 @@ export const LinearIssue = ({ code }: { code: string }) => {
   const assignee = fetchAssignee.data
 
   return (
-    <div className="flex items-center justify-between gap-1.5 border-b border-gray-300 last:border-0 px-4 py-2">
+    <div className="flex items-center justify-between gap-1.5 border-b border-[--borderColor-default] last:border-0 px-4 py-2">
       <div className="flex gap-1.5 items-center">
         <Tooltip content="Manage priority" on={['hover', 'focus']}>
           <PriorityPopover issue={issue} />
@@ -61,7 +61,7 @@ export const LinearIssue = ({ code }: { code: string }) => {
         {issue ? (
           <div>
             <a
-              className="hover:text-black hover:underline underline-offset-3 line-clamp-2"
+              className="hover:text-[--fgColor-default] hover:underline underline-offset-3 line-clamp-2 text-[--fgColor-muted] transition-colors"
               href={issue.url}
               target={code}
               title={issue.title || ''}

--- a/packages/linear/src/components/PriorityPopover.tsx
+++ b/packages/linear/src/components/PriorityPopover.tsx
@@ -44,7 +44,7 @@ export const PriorityPopover = ({ issue }: PriorityPopoverProps) => {
     <Tooltip
       className="p-1 min-w-48"
       content={
-        <div className="whitespace-nowrap *:flex *:gap-2 *:items-center *:w-full *:px-2.5 *:py-1.5 *:rounded-md *:cursor-pointer hover:*:bg-gray-100">
+        <div className="whitespace-nowrap *:flex *:gap-2 *:items-center *:w-full *:px-2.5 *:py-1.5 *:rounded-md *:cursor-pointer hover:*:bg-[--bgColor-accent-emphasis]">
           <button onClick={changePriority(0)} type="button">
             <PriorityNone />
             <div>No priority</div>

--- a/packages/linear/src/components/PriorityPopover.tsx
+++ b/packages/linear/src/components/PriorityPopover.tsx
@@ -44,7 +44,7 @@ export const PriorityPopover = ({ issue }: PriorityPopoverProps) => {
     <Tooltip
       className="p-1 min-w-48"
       content={
-        <div className="whitespace-nowrap *:flex *:gap-2 *:items-center *:w-full *:px-2.5 *:py-1.5 *:rounded-md *:cursor-pointer hover:*:bg-[--bgColor-accent-emphasis]">
+        <div className="whitespace-nowrap *:flex *:gap-2 *:items-center *:w-full *:px-2.5 *:py-1.5 *:rounded-md *:cursor-pointer hover:*:bg-[--bgColor-neutral-muted]">
           <button onClick={changePriority(0)} type="button">
             <PriorityNone />
             <div>No priority</div>

--- a/packages/linear/src/components/StatusPopover.tsx
+++ b/packages/linear/src/components/StatusPopover.tsx
@@ -105,7 +105,7 @@ export const StatusPopover = ({ issue, status }: StatusPopoverProps) => {
     <Tooltip
       className="p-1 min-w-48"
       content={
-        <div className="whitespace-nowrap *:flex *:gap-2 *:items-center *:w-full *:px-2.5 *:py-1.5 *:rounded-md *:cursor-pointer hover:*:bg-gray-100">
+        <div className="whitespace-nowrap *:flex *:gap-2 *:items-center *:w-full *:px-2.5 *:py-1.5 *:rounded-md *:cursor-pointer hover:*:bg-[--bgColor-accent-emphasis]">
           {statuses.map((_status, index) => (
             <button key={_status.id} onClick={changeStatus(_status.id)} type="button">
               <StateIcon state={_status} states={statuses} />

--- a/packages/linear/src/components/StatusPopover.tsx
+++ b/packages/linear/src/components/StatusPopover.tsx
@@ -105,7 +105,7 @@ export const StatusPopover = ({ issue, status }: StatusPopoverProps) => {
     <Tooltip
       className="p-1 min-w-48"
       content={
-        <div className="whitespace-nowrap *:flex *:gap-2 *:items-center *:w-full *:px-2.5 *:py-1.5 *:rounded-md *:cursor-pointer hover:*:bg-[--bgColor-accent-emphasis]">
+        <div className="whitespace-nowrap *:flex *:gap-2 *:items-center *:w-full *:px-2.5 *:py-1.5 *:rounded-md *:cursor-pointer hover:*:bg-[--bgColor-neutral-muted]">
           {statuses.map((_status, index) => (
             <button key={_status.id} onClick={changeStatus(_status.id)} type="button">
               <StateIcon state={_status} states={statuses} />

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -138,7 +138,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
             <div
               {...interactions.getFloatingProps({
                 className: cn(
-                  'Tooltip z-modals bg-white border border-greyDark stroke-greyDark rounded-md shadow-md text-sm px-2 py-1',
+                  'Tooltip z-modals bg-[--overlay-bgColor] border border-[--borderColor-default] stroke-[--borderColor-default] rounded-md shadow-md text-sm px-2 py-1',
                   className,
                 ),
                 ref: floating.context.refs.setFloating,
@@ -147,7 +147,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
             >
               {content}
               <FloatingArrow
-                className="size-4 fill-white *:border-none *:stroke-inherit [&>path:first-of-type]:stroke-2 [&>path:last-of-type]:stroke-none [&>path:last-of-type]:stroke-0"
+                className="size-4 fill-[--overlay-bgColor] *:border-none *:stroke-inherit [&>path:first-of-type]:stroke-2 [&>path:last-of-type]:stroke-none [&>path:last-of-type]:stroke-0"
                 context={floating.context}
                 ref={arrowRef}
                 strokeWidth={1}


### PR DESCRIPTION
Summary

Fixes style to always match the current Github theme.

**refs:**

Closes #52 

**test plan:**

Tested all github themes. Not perfect (like accent color not always matching), but probably good enough :-)

<img width="1277" height="271" alt="image" src="https://github.com/user-attachments/assets/e251f382-dc12-4d83-99db-7a26879710ef" />

